### PR TITLE
nonce throttle to prevent btc-e from using the same nonce parameter on a...

### DIFF
--- a/btc-e.js
+++ b/btc-e.js
@@ -29,7 +29,7 @@ var BTCE = function(apiKey, secret, nonceGenerator) {
       // nonce throttle
       if (nonce === self.nonceLast) {
         setTimeout(function() {
-          self.makeRequest.call(self);
+          self.makeRequest(method, params, callback);
         }, 50);
         return;
       }


### PR DESCRIPTION
...pi calls

probably this is a solution
if the api responds really fast and the next call can happen to use the same nonce value the other way.
So I propose to make it wait 50 ms and check again until a second since that last call has passed.
